### PR TITLE
Windows Fix - Paths could not be created

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -138,6 +138,10 @@ page.onResourceRequested = function(request, networkRequest) {
     }
   }
   
+  // Phantom can not serve static content at this point.
+  // So the file is stored in a temp dictionary and phantom is rerouted.
+  // The name of the temp file is an escaped version of the original path.
+  // The escaped path (id) is only used locally in this function.
   function changeContentHack(id,content){
     var escaped = [/:/g, /\//g, /\\/g]; //may need more characters
     id = id.replace(/@/g,"@@");


### PR DESCRIPTION
There were problems when generating temp files to serve the "istanbul-ised" scripts back to phantom.
When the C:/testfile.js was stored, it was attempted to save this at .../temp/C:/testfile.js which is not a valid path. This fix escapes the path to generate just a single file under temp.

If you except this pull, would you consider redeploying to npm?

Thanks, Florian Rüberg (florian.rueberg@gmail.com)
