### PR TITLE
Fix request url prefix

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -107,7 +107,7 @@ page.onResourceRequested = function(request, networkRequest) {
   var isFile = request.url.search('file://') !== -1;
   var isHttp = request.url.search('http://') !== -1;
   var isHttps = request.url.search('https://') !== -1;
-  var currentFile, content;
+  var currentFile, content, prefix;
 
   // Phantom can not serve static content at this point.
   // So the file is stored in a temp dictionary and phantom is rerouted.
@@ -121,12 +121,13 @@ page.onResourceRequested = function(request, networkRequest) {
     }
     id = options.transport.instrumentedFiles + '/' + id;
     fs.write(id, content, 'w');
-    networkRequest.changeUrl(id);
+    networkRequest.changeUrl(prefix + id);
   }
 
   // process file based ressources
   if (isFile) {
-    currentFile = request.url.replace('file://', '');
+    prefix = 'file://';
+    currentFile = request.url.replace(prefix, '');
     currentFile = currentFile.replace(/%20/g, ' ');
 
     // check for query params (and thropw them away)
@@ -142,8 +143,9 @@ page.onResourceRequested = function(request, networkRequest) {
 
   // process http based ressources
   if (isHttp || isHttps) {
+    prefix = isHttp ? 'http://' : 'https://';
     var undef;
-    var temp = isHttp ? request.url.replace('http://', '').split('/') : request.url.replace('https://', '').split('/');
+    var temp = request.url.replace(prefix, '').split('/');
     temp.shift();
     currentFile = temp.join('/');
     if (!!instrumentedFiles[currentFile]) {


### PR DESCRIPTION
Currently, when the request url is changed for instrumented files, the protocol prefix isn't being carried through. This causes problems in newer versions of Phantom.