### PR TITLE
Update main.js

### DIFF
--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -122,6 +122,16 @@ page.onResourceRequested = function(request, networkRequest) {
     id = options.transport.instrumentedFiles + '/' + id;
     fs.write(id, content, 'w');
     networkRequest.changeUrl(prefix + id);
+     if(isHttp || isHttps)
+     {
+       //get the hostname from the request object.
+       var hostname = request.url.replace(prefix, '').split('/')[0];
+       networkRequest.changeUrl(prefix + hostname + '/' + id); /*For HTML test files served by a web server (e.g., localhost),
+                                                                 the change Url MUST include the hostname else the Url is unresolved
+                                                                 which generates an error in PhantomJS.*/ 
+     }else{
+       networkRequest.changeUrl(prefix + id); 
+     }
   }
 
   // process file based ressources


### PR DESCRIPTION
Added logic that adds the hostname (e.g., localhost) to the constructed change Url if the source file is being served by a web server. This change was necessary to prevent an unreachable Url which results in a timeout in PhantomJS and an empty code coverage file.