### PR TITLE
update tempfile.unlink() to tempfile.unlinkSync()

### DIFF
--- a/lib/phantomjs.js
+++ b/lib/phantomjs.js
@@ -54,7 +54,7 @@ exports.init = function(grunt) {
     // All done? Clean up!
     var cleanup = function(done, immediate) {
       clearTimeout(id);
-      tempfile.unlink();
+      tempfile.unlinkSync();
       var kill = function(){
         // Only kill process if it has a pid, otherwise an error would be thrown.
         if (phantomJSHandle.pid){


### PR DESCRIPTION
Using this module in Node 10 I'm getting this error when running grunt tasks:

```
Fatal error: Callback must be a function
```
The problem appears to be fixed here in other grunt modules:
https://github.com/gruntjs/grunt-contrib-jasmine/issues/266

It looks like in Node 10 this error is being thrown because unlink() is expecting a callback; updating `tempfile.unlink()` to `tempfile.unlinkSync()` will fix this.